### PR TITLE
Update to correct parameter name

### DIFF
--- a/src/SFA.DAS.Payments.RequiredPayments.ServiceFabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/SFA.DAS.Payments.RequiredPayments.ServiceFabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -48,7 +48,7 @@
           </Section>
           <Section Name="Settings">
             <Parameter Name="EndpointName" Value="[RequiredPaymentsService_EndpointName]" />
-            <Parameter Name="FailedMessagesQueue" Value="[ProviderPaymentsService_FailedMessagesQueue]" />
+            <Parameter Name="FailedMessagesQueue" Value="[RequiredPaymentsService_FailedMessagesQueue]" />
           </Section>
         </Settings>
       </ConfigOverride>


### PR DESCRIPTION
Without this change the PaymentService ServiceFabric solution will not deploy as a parameter is missing (incorrectly named).