### PR TITLE
Add configuration for running tests against DC services

### DIFF
--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Automation/TestSession.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Automation/TestSession.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
         public long Ukprn => Provider.Ukprn;
         public long JobId => Provider.JobId;
 
-        private readonly IUkprnService _ukprnService = new RandomUkprnService();
+        private readonly IUkprnService _ukprnService;
 
         public Employer GetEmployer(string identifier)
         {
@@ -47,8 +47,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
             return employer;
         }
 
-        public TestSession(long? ukprn = null)
+        public TestSession(IUkprnService ukprnService)
         {
+            _ukprnService = ukprnService;
+
             courseFaker = new Faker<Course>();
             courseFaker
                 .RuleFor(course => course.AimSeqNumber, faker => faker.Random.Short(1))
@@ -73,9 +75,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
 
         }
 
-        public TestSession(IUkprnService ukprnService) : this()
+        public TestSession(long? ukprn = null) : this(new RandomUkprnService())
         {
-            _ukprnService = ukprnService;
         }
 
         public long GenerateId(int maxValue = 1000000)

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Automation/TestSession.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Automation/TestSession.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Bogus;
 using SFA.DAS.Payments.AcceptanceTests.Core.Data;
+using SFA.DAS.Payments.AcceptanceTests.Services;
+using SFA.DAS.Payments.AcceptanceTests.Services.Intefaces;
 
 namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
 {
@@ -28,6 +30,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
         public long Ukprn => Provider.Ukprn;
         public long JobId => Provider.JobId;
 
+        private readonly IUkprnService _ukprnService = new RandomUkprnService();
 
         public Employer GetEmployer(string identifier)
         {
@@ -70,6 +73,11 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
 
         }
 
+        public TestSession(IUkprnService ukprnService) : this()
+        {
+            _ukprnService = ukprnService;
+        }
+
         public long GenerateId(int maxValue = 1000000)
         {
             var id = random.Next(maxValue);
@@ -79,14 +87,14 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Automation
 
         public void RegenerateUkprn()
         {
-            Provider.Ukprn = GenerateId();
+            Provider.Ukprn = _ukprnService.GenerateUkprn();
         }
 
         private Provider GenerateProvider()
         {
             return new Provider
             {
-                Ukprn = GenerateId(),
+                Ukprn = _ukprnService.GenerateUkprn(),
                 JobId = GenerateId(),
                 IlrSubmissionTime = DateTime.UtcNow
             };

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/BindingBootstrapper.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/BindingBootstrapper.cs
@@ -10,6 +10,8 @@ using NServiceBus;
 using NServiceBus.Faults;
 using NServiceBus.Features;
 using SFA.DAS.Payments.AcceptanceTests.Core.Automation;
+using SFA.DAS.Payments.AcceptanceTests.Services;
+using SFA.DAS.Payments.AcceptanceTests.Services.Intefaces;
 using SFA.DAS.Payments.Messages.Core;
 using SFA.DAS.Payments.Monitoring.Jobs.Client;
 using TechTalk.SpecFlow;
@@ -36,6 +38,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Infrastructure
                 .SingleInstance();
             var conventions = EndpointConfiguration.Conventions();
             conventions.DefiningMessagesAs(type => type.IsMessage());
+
+            Builder.RegisterType<UkprnService>().As<IUkprnService>().InstancePerLifetimeScope();
 
             EndpointConfiguration.UsePersistence<AzureStoragePersistence>()
                 .ConnectionString(config.StorageConnectionString);

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/BindingBootstrapper.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/BindingBootstrapper.cs
@@ -39,7 +39,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Infrastructure
             var conventions = EndpointConfiguration.Conventions();
             conventions.DefiningMessagesAs(type => type.IsMessage());
 
-            Builder.RegisterType<UkprnService>().As<IUkprnService>().InstancePerLifetimeScope();
+            var ukprnServiceType = config.ValidateDcAndDasServices ? typeof(UkprnService) : typeof(RandomUkprnService);
+            Builder.RegisterType(ukprnServiceType).As<IUkprnService>().InstancePerLifetimeScope();
 
             EndpointConfiguration.UsePersistence<AzureStoragePersistence>()
                 .ConnectionString(config.StorageConnectionString);

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/TestSessionBase.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/TestSessionBase.cs
@@ -4,6 +4,7 @@ using Autofac;
 using NServiceBus;
 using NUnit.Framework;
 using SFA.DAS.Payments.AcceptanceTests.Core.Automation;
+using SFA.DAS.Payments.AcceptanceTests.Services.Intefaces;
 using TechTalk.SpecFlow;
 
 namespace SFA.DAS.Payments.AcceptanceTests.Core.Infrastructure
@@ -18,7 +19,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Infrastructure
         {
             var scope = Container.BeginLifetimeScope(builder => builder.RegisterInstance<IMessageSession>(MessageSession));
             context.Set(scope, "container_scope");
-            var testSession = new TestSession();
+            var testSession = new TestSession(Container.Resolve<IUkprnService>());
             context.Set(testSession);
             Console.WriteLine($"Created test session: Ukprn: {testSession.Ukprn}, Job Id: {testSession.JobId}");
         }

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/TestsConfiguration.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Infrastructure/TestsConfiguration.cs
@@ -9,6 +9,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Infrastructure
         public string StorageConnectionString => GetConnectionString("StorageConnectionString");
         public string ServiceBusConnectionString => GetConnectionString("ServiceBusConnectionString");
         public string PaymentsConnectionString => GetConnectionString("PaymentsConnectionString");
+        public bool ValidateDcAndDasServices => bool.Parse(ConfigurationManager.AppSettings["ValidateDcAndDasServices"] ?? "false");
         public TimeSpan TimeToWait => TimeSpan.Parse(ConfigurationManager.AppSettings["TimeToWait"] ?? "00:00:30");
         public TimeSpan TimeToWaitForUnexpected => TimeSpan.Parse(ConfigurationManager.AppSettings["TimeToWaitForUnexpected"] ?? "00:00:30");
         public TimeSpan TimeToPause => TimeSpan.Parse(ConfigurationManager.AppSettings["TimeToPause"] ?? "00:00:05");

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/SFA.DAS.Payments.AcceptanceTests.Core.csproj
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/SFA.DAS.Payments.AcceptanceTests.Core.csproj
@@ -340,6 +340,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Payments.AcceptanceTests.Services\SFA.DAS.Payments.AcceptanceTests.Services.csproj">
+      <Project>{c367da42-6ed6-4028-b754-f39148f5d2c8}</Project>
+      <Name>SFA.DAS.Payments.AcceptanceTests.Services</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Payments.Core\SFA.DAS.Payments.Core.csproj">
       <Project>{F6E38368-C397-488B-B041-D3E8423C1CE1}</Project>
       <Name>SFA.DAS.Payments.Core</Name>

--- a/src/SFA.DAS.Payments.AcceptanceTests.Services/Intefaces/IUkprnService.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Services/Intefaces/IUkprnService.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.Payments.AcceptanceTests.Services.Intefaces
+{
+    public interface IUkprnService
+    {
+        int GenerateUkprn();
+    }
+}

--- a/src/SFA.DAS.Payments.AcceptanceTests.Services/SFA.DAS.Payments.AcceptanceTests.Services.csproj
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Services/SFA.DAS.Payments.AcceptanceTests.Services.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/SFA.DAS.Payments.AcceptanceTests.Services/Services/RandomUkprnService.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Services/Services/RandomUkprnService.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.Payments.AcceptanceTests.Services
+{
+    using Intefaces;
+    using System;
+
+    public class RandomUkprnService : IUkprnService
+    {
+        private const int MaximumUkprn = 1_000_000;
+        private readonly Random random = new Random(Guid.NewGuid().GetHashCode());
+
+        public int GenerateUkprn() => random.Next(MaximumUkprn);
+    }
+}

--- a/src/SFA.DAS.Payments.AcceptanceTests.Services/Services/UkprnService.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Services/Services/UkprnService.cs
@@ -1,0 +1,14 @@
+﻿namespace SFA.DAS.Payments.AcceptanceTests.Services
+{
+    using Intefaces;
+
+    public class UkprnService : IUkprnService
+    {
+        public int GenerateUkprn()
+        {
+            // Todo: implement a service!
+
+            return 10036143;
+        }
+    }
+}

--- a/src/SFA.DAS.Payments.PerformanceTests/EndToEndPerformanceTests.cs
+++ b/src/SFA.DAS.Payments.PerformanceTests/EndToEndPerformanceTests.cs
@@ -89,7 +89,7 @@ namespace SFA.DAS.Payments.PerformanceTests
         {
             Randomizer.Seed = new Random(8675309);
             var sessions = Enumerable.Range(1, providerCount)
-                .Select(i => new TestSession(i))
+                .Select(i => new TestSession(ukprn: i))
                 .ToList();
             var ilrSubmissions = new List<Task>();
             if (providerLearnerCount > 1)

--- a/src/SFA.DAS.Payments.sln
+++ b/src/SFA.DAS.Payments.sln
@@ -207,6 +207,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Payments.DataLocks.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Payments.DataLocks.Domain.UnitTests", "SFA.DAS.Payments.DataLocks.Domain.UnitTests\SFA.DAS.Payments.DataLocks.Domain.UnitTests.csproj", "{069043DF-89A2-485D-A71F-88EBA5274F12}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Payments.AcceptanceTests.Services", "SFA.DAS.Payments.AcceptanceTests.Services\SFA.DAS.Payments.AcceptanceTests.Services.csproj", "{C367DA42-6ED6-4028-B754-F39148F5D2C8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -921,6 +923,14 @@ Global
 		{069043DF-89A2-485D-A71F-88EBA5274F12}.Release|Any CPU.Build.0 = Release|Any CPU
 		{069043DF-89A2-485D-A71F-88EBA5274F12}.Release|x64.ActiveCfg = Release|Any CPU
 		{069043DF-89A2-485D-A71F-88EBA5274F12}.Release|x64.Build.0 = Release|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Debug|x64.Build.0 = Debug|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Release|x64.ActiveCfg = Release|Any CPU
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1013,6 +1023,7 @@ Global
 		{81DFA62B-3406-4C32-AD4E-CB036C4BDB36} = {7B48662F-1F86-461C-8638-AC1DDCE3B8B4}
 		{88F8C227-EFFC-47C7-80A4-EC7854EC813E} = {45300BA0-FCE3-41CA-8BC0-FDBFF89352F3}
 		{069043DF-89A2-485D-A71F-88EBA5274F12} = {7B48662F-1F86-461C-8638-AC1DDCE3B8B4}
+		{C367DA42-6ED6-4028-B754-F39148F5D2C8} = {6B05550F-FBCB-47A1-856D-1A333A0CEDEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4E9E6D1E-3C3C-41C9-AED4-9B6DC9118F1F}


### PR DESCRIPTION
When the configuration value `ValidateDcAndDasServices` is set to `true`, the tests will (in future) pick UKPRN from a well known list, and manipulate DC to provide ILR details for Payments services.  

When disabled or absent, the current behaviour of using random UKPRNs will be used.