### PR TITLE
pv2-1409 remove exception logging behaviour

### DIFF
--- a/src/SFA.DAS.Payments.Application/Infrastructure/Ioc/Modules/MessagingModule.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Ioc/Modules/MessagingModule.cs
@@ -5,6 +5,8 @@ using System.Web;
 using Autofac;
 using NServiceBus;
 using NServiceBus.Features;
+using NServiceBus.Logging;
+using SFA.DAS.Payments.Application.Infrastructure.Logging;
 using SFA.DAS.Payments.Application.Messaging;
 using SFA.DAS.Payments.Application.Messaging.Telemetry;
 using SFA.DAS.Payments.Core.Configuration;
@@ -15,8 +17,13 @@ namespace SFA.DAS.Payments.Application.Infrastructure.Ioc.Modules
     {
         protected override void Load(ContainerBuilder builder)
         {
+            builder.RegisterType<MessagingLoggerFactory>();
+            builder.RegisterType<MessagingLogger>();
+
             builder.Register((c, p) =>
             {
+                LogManager.UseFactory(c.Resolve<MessagingLoggerFactory>());
+
                 var config = c.Resolve<IApplicationConfiguration>();
 
                 var endpointName = new EndpointName(config.EndpointName);

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/IApplicationLoggerSettingsExtensions.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/IApplicationLoggerSettingsExtensions.cs
@@ -1,0 +1,12 @@
+﻿using ESFA.DC.Logging.Config.Interfaces;
+using ESFA.DC.Logging.Enums;
+using System.Linq;
+
+namespace SFA.DAS.Payments.Application.Infrastructure.Logging
+{
+    public static class IApplicationLoggerSettingsExtensions
+    {
+        public static LogLevel MinimumLogLevel(this IApplicationLoggerSettings settings)
+            => settings.ApplicationLoggerOutputSettingsCollection.Min(x => x.MinimumLogLevel);
+    }
+}

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.Payments.Application.Infrastructure.Logging
 
         public void Warn(string message) => logger.LogWarning(message);
 
-        public void Warn(string message, Exception exception) => logger.LogWarning(message);
+        public void Warn(string message, Exception exception) => WarnFormat("{0}\n{1}", message, exception.Message);
 
         public void WarnFormat(string format, params object[] args) => logger.LogWarning(format, args);
     }

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using NServiceBus.Logging;
+
+namespace SFA.DAS.Payments.Application.Infrastructure.Logging
+{
+    internal class MessagingLogger : ILog
+    {
+        private readonly IPaymentLogger logger;
+
+        public MessagingLogger(IPaymentLogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        // IPaymentLogger does not expose the minimum level it is configured for,
+        // so we must enable all levels and bear the cost of low-level messages being
+        // discarded by IPaymenLogger.
+        public bool IsDebugEnabled => true;
+
+        public bool IsInfoEnabled => true;
+        public bool IsWarnEnabled => true;
+        public bool IsErrorEnabled => true;
+        public bool IsFatalEnabled => true;
+
+        public void Debug(string message) => DebugFormat(message);
+
+        public void Debug(string message, Exception exception) => Debug(message);
+
+        public void DebugFormat(string format, params object[] args) => logger.LogDebug(format, args);
+
+        public void Error(string message) => logger.LogError(message);
+
+        public void Error(string message, Exception exception) => logger.LogError(message, exception);
+
+        public void ErrorFormat(string format, params object[] args) => logger.LogError(format, parameters: args);
+
+        public void Fatal(string message) => logger.LogFatal(message);
+
+        public void Fatal(string message, Exception exception) => logger.LogFatal(message, exception);
+
+        public void FatalFormat(string format, params object[] args) => logger.LogFatal(format, parameters: args);
+
+        public void Info(string message) => logger.LogInfo(message);
+
+        public void Info(string message, Exception exception) => logger.LogInfo(message);
+
+        public void InfoFormat(string format, params object[] args) => logger.LogInfo(format, args);
+
+        public void Warn(string message) => logger.LogWarning(message);
+
+        public void Warn(string message, Exception exception) => logger.LogWarning(message);
+
+        public void WarnFormat(string format, params object[] args) => logger.LogWarning(format, args);
+    }
+}

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLogger.cs
@@ -1,26 +1,29 @@
-﻿using System;
+﻿using ESFA.DC.Logging.Config.Interfaces;
 using NServiceBus.Logging;
+using System;
 
 namespace SFA.DAS.Payments.Application.Infrastructure.Logging
 {
     internal class MessagingLogger : ILog
     {
         private readonly IPaymentLogger logger;
+        private readonly ESFA.DC.Logging.Enums.LogLevel minimum;
 
-        public MessagingLogger(IPaymentLogger logger)
+        public MessagingLogger(IPaymentLogger logger, IApplicationLoggerSettings settings)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            minimum = settings.MinimumLogLevel();
         }
 
-        // IPaymentLogger does not expose the minimum level it is configured for,
-        // so we must enable all levels and bear the cost of low-level messages being
-        // discarded by IPaymenLogger.
-        public bool IsDebugEnabled => true;
+        public bool IsDebugEnabled => minimum >= ESFA.DC.Logging.Enums.LogLevel.Debug;
 
-        public bool IsInfoEnabled => true;
-        public bool IsWarnEnabled => true;
-        public bool IsErrorEnabled => true;
-        public bool IsFatalEnabled => true;
+        public bool IsInfoEnabled => minimum >= ESFA.DC.Logging.Enums.LogLevel.Information;
+
+        public bool IsWarnEnabled => minimum >= ESFA.DC.Logging.Enums.LogLevel.Warning;
+
+        public bool IsErrorEnabled => minimum >= ESFA.DC.Logging.Enums.LogLevel.Error;
+
+        public bool IsFatalEnabled => minimum >= ESFA.DC.Logging.Enums.LogLevel.Fatal;
 
         public void Debug(string message) => DebugFormat(message);
 

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLoggerFactory.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLoggerFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ESFA.DC.Logging.Config.Interfaces;
 using NServiceBus.Logging;
 
 namespace SFA.DAS.Payments.Application.Infrastructure.Logging
@@ -6,20 +7,22 @@ namespace SFA.DAS.Payments.Application.Infrastructure.Logging
     internal class MessagingLoggerFactory : ILoggerFactory
     {
         private readonly IPaymentLogger logger;
+        private readonly IApplicationLoggerSettings settings;
 
-        public MessagingLoggerFactory(IPaymentLogger logger)
+        public MessagingLoggerFactory(IPaymentLogger logger, IApplicationLoggerSettings settings)
         {
             this.logger = logger;
+            this.settings = settings;
         }
 
         public ILog GetLogger(Type type)
         {
-            return new MessagingLogger(logger);
+            return new MessagingLogger(logger, settings);
         }
 
         public ILog GetLogger(string name)
         {
-            return new MessagingLogger(logger);
+            return new MessagingLogger(logger, settings);
         }
     }
 }

--- a/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLoggerFactory.cs
+++ b/src/SFA.DAS.Payments.Application/Infrastructure/Logging/MessagingLoggerFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NServiceBus.Logging;
+
+namespace SFA.DAS.Payments.Application.Infrastructure.Logging
+{
+    internal class MessagingLoggerFactory : ILoggerFactory
+    {
+        private readonly IPaymentLogger logger;
+
+        public MessagingLoggerFactory(IPaymentLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public ILog GetLogger(Type type)
+        {
+            return new MessagingLogger(logger);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new MessagingLogger(logger);
+        }
+    }
+}

--- a/src/SFA.DAS.Payments.Application/Messaging/ExceptionHandlingBehavior.cs
+++ b/src/SFA.DAS.Payments.Application/Messaging/ExceptionHandlingBehavior.cs
@@ -1,14 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NServiceBus.Pipeline;
+using NServiceBus.Transport;
 using SFA.DAS.Payments.Application.Infrastructure.Logging;
 using SFA.DAS.Payments.Core;
 
 namespace SFA.DAS.Payments.Application.Messaging
 {
-    public class ExceptionHandlingBehavior : Behavior<ITransportReceiveContext>
+    public class ExceptionHandlingBehavior : Behavior<IIncomingLogicalMessageContext>
     {
         private readonly IPaymentLogger logger;
 
@@ -17,7 +19,7 @@ namespace SFA.DAS.Payments.Application.Messaging
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+        public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
         {
             try
             {
@@ -25,17 +27,47 @@ namespace SFA.DAS.Payments.Application.Messaging
             }
             catch (Exception ex)
             {
-                if (!(context.Message.Headers.TryGetValue("NServiceBus.EnclosedMessageTypes", out var messageType) 
+                if (!(context.Headers.TryGetValue("NServiceBus.EnclosedMessageTypes", out var messageType) 
                     && TypeString.TryParseTypeName(messageType, out messageType)))
                 {
                     messageType = "No enclosed messages";
                 }
 
-                if (!context.Message.Headers.TryGetValue("NServiceBus.OriginatingEndpoint", out var sendingEndpoint))
+                if (!context.Headers.TryGetValue("NServiceBus.OriginatingEndpoint", out var sendingEndpoint))
                     sendingEndpoint = "No sending endpoint";
 
-                throw new MessageProcessingFailedException($"Couldn't process message `{messageType}` from `{sendingEndpoint}`.", context.Message, ex);
+                var add = AdditionalProperties(context.Message);
+                var props = string.Join(", ", add.Select(x => $"{x.Key}: {x.Value}"));
+
+                throw new MessageProcessingFailedException($"Couldn't process message `{messageType}` from `{sendingEndpoint}`.\n{props}", context.Message, ex);
             }
+        }
+
+        private Dictionary<string,string> AdditionalProperties(LogicalMessage message)
+        {
+            var props = new List<string> { "Id", "EmployerAccountId", "AccountId", "Ukprn", "JobId", "EventId", "ContractType", "TransactionType" };
+
+            return props.ToDictionaryWithoutNullValues(key => key, key => GetMessageProperty(message, key));
+        }
+
+        private static string GetMessageProperty(LogicalMessage message, string propertyName)
+        {
+            return message.Instance.GetType().GetProperty(propertyName)?.GetValue(message.Instance, null)?.ToString();
+        }
+    }
+
+    public static class DictionaryExtensions
+    {
+        public static Dictionary<TKey, TValue> ToDictionaryWithoutNullValues<TSource, TKey, TValue>(this IEnumerable<TSource> keys, Func<TSource, TKey> keySelector, Func<TSource, TValue> valueSelector)
+        {
+            // message.Learner?.ReferenceNumber
+            // message.Learner.LearnRefNumber
+            //{message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}"
+             
+            return keys
+                .Select(x => (key: keySelector(x), value: valueSelector(x)))
+                .Where(x => x.value != null)
+                .ToDictionary(x => x.key, x => x.value);
         }
     }
 

--- a/src/SFA.DAS.Payments.Application/Messaging/MessageProcessingFailedException.cs
+++ b/src/SFA.DAS.Payments.Application/Messaging/MessageProcessingFailedException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.Serialization;
+using NServiceBus.Transport;
+
+namespace SFA.DAS.Payments.Application.Messaging
+{
+    [Serializable]
+    internal class MessageProcessingFailedException : Exception
+    {
+        private readonly string message;
+        private readonly IncomingMessage incomingMessage;
+        private readonly Exception innerException;
+
+
+        public MessageProcessingFailedException(string message, IncomingMessage incomingMessage, Exception innerException) : base(message, innerException)
+        {
+            this.message = message;
+            this.incomingMessage = incomingMessage;
+            this.innerException = innerException;
+        }
+
+        protected MessageProcessingFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/SFA.DAS.Payments.Application/Messaging/MessageProcessingFailedException.cs
+++ b/src/SFA.DAS.Payments.Application/Messaging/MessageProcessingFailedException.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using NServiceBus.Pipeline;
+using System;
 using System.Runtime.Serialization;
-using NServiceBus.Transport;
 
 namespace SFA.DAS.Payments.Application.Messaging
 {
@@ -8,11 +8,11 @@ namespace SFA.DAS.Payments.Application.Messaging
     internal class MessageProcessingFailedException : Exception
     {
         private readonly string message;
-        private readonly IncomingMessage incomingMessage;
+        private readonly LogicalMessage incomingMessage;
         private readonly Exception innerException;
 
 
-        public MessageProcessingFailedException(string message, IncomingMessage incomingMessage, Exception innerException) : base(message, innerException)
+        public MessageProcessingFailedException(string message, LogicalMessage incomingMessage, Exception innerException) : base(message, innerException)
         {
             this.message = message;
             this.incomingMessage = incomingMessage;

--- a/src/SFA.DAS.Payments.Core/TypeString.cs
+++ b/src/SFA.DAS.Payments.Core/TypeString.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SFA.DAS.Payments.Core
+{
+    public static class TypeString
+    {
+        public static bool TryParseTypeName(string typesString, out string typeName)
+        {
+            // e.g. "Some.Namespace.Class, Some.OtherNamespace.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;"
+            // Extract "Class"
+            var match = new Regex(@"(\w+),").Match(typesString);
+
+            if (match.Groups.Count < 1)
+            {
+                typeName = null;
+                return false;
+            }
+            else
+            {
+                typeName = match.Groups[1].Value;
+                return true;
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.Payments.DataLocks.ApprovalsService/Handlers/BaseApprovalsMessageHandler.cs
+++ b/src/SFA.DAS.Payments.DataLocks.ApprovalsService/Handlers/BaseApprovalsMessageHandler.cs
@@ -21,20 +21,12 @@ namespace SFA.DAS.Payments.DataLocks.ApprovalsService.Handlers
 
         public async Task Handle(T message, IMessageHandlerContext context)
         {
-            try
+            Logger.LogVerbose($"Creating scope for handling message: {typeof(T).Name}");
+            using (var scope = factory.CreateScope())
             {
-                Logger.LogVerbose($"Creating scope for handling message: {typeof(T).Name}");
-                using (var scope = factory.CreateScope())
-                {
-                    await HandleMessage(message, context, scope);
-                }
-                Logger.LogVerbose($"Finished handling message : {typeof(T).Name}");
+                await HandleMessage(message, context, scope);
             }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Error handling {typeof(T).Name} message. Error: {ex.Message}", ex);
-                throw;
-            }
+            Logger.LogVerbose($"Finished handling message : {typeof(T).Name}");
         }
 
         protected abstract Task HandleMessage(T message, IMessageHandlerContext context, ILifetimeScope scope);

--- a/src/SFA.DAS.Payments.DataLocks.DataLockEventService/Handlers/DataLockStatusChangedEventHandler.cs
+++ b/src/SFA.DAS.Payments.DataLocks.DataLockEventService/Handlers/DataLockStatusChangedEventHandler.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
@@ -21,18 +19,11 @@ namespace SFA.DAS.Payments.DataLocks.DataLockEventService.Handlers
             this.eventProcessor = eventProcessor ?? throw new ArgumentNullException(nameof(eventProcessor));
         }
 
-        public async Task Handle(DataLockStatusChanged message, IMessageHandlerContext context)
+        public Task Handle(DataLockStatusChanged message, IMessageHandlerContext context)
         {
             paymentLogger.LogDebug($"Processing {message.GetType().Name} event for UKPRN {message.Ukprn}");
 
-            try
-            {
-                await eventProcessor.EnqueueEvent(message, CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                throw new ApplicationException($"Error processing {message.GetType().Name} event for UKPRN {message.Ukprn}", ex);
-            }
+            return eventProcessor.EnqueueEvent(message, CancellationToken.None);
         }
     }
 }

--- a/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipContractType1EarningEventHandler.cs
+++ b/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipContractType1EarningEventHandler.cs
@@ -24,40 +24,32 @@ namespace SFA.DAS.Payments.DataLocks.DataLockProxyService.Handlers
 
         public async Task Handle(ApprenticeshipContractType1EarningEvent message, IMessageHandlerContext context)
         {
-            try
+            if (message.Learner == null || message.Learner?.Uln == 0)
             {
-                if (message.Learner == null || message.Learner?.Uln == 0)
-                {
-                    throw new InvalidOperationException("Invalid 'ApprenticeshipContractType1EarningEvent' received. Learner was null or Uln was 0.");
-                }
-                var uln = message.Learner.Uln;
-                var learnerRef = message.Learner.ReferenceNumber;
-                logger.LogDebug($"Processing DataLockProxyProxyService event for learner with learner ref {learnerRef}");
-                var actorId = new ActorId(uln);
-
-                logger.LogVerbose($"Creating actor proxy for learner with learner ref {learnerRef}");
-                var actor = proxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
-                logger.LogDebug($"Actor proxy created for learner with ULN {uln}");
-
-                logger.LogVerbose($"Calling actor proxy to handle earning for learner with learner ref {learnerRef}");
-                var dataLockEvents = await actor.HandleEarning(message, CancellationToken.None).ConfigureAwait(false);
-                logger.LogDebug($"Earning handled for learner with learner ref {learnerRef}");
-
-                if (dataLockEvents != null)
-                {
-                    var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
-                    logger.LogVerbose($"Publishing data lock event for learner with learner ref {learnerRef}: {summary}");
-                    await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
-                    logger.LogDebug($"Data lock event published for learner with learner ref {learnerRef}");
-                }
-
-                logger.LogInfo($"Successfully processed DataLockProxyProxyService event for Actor Id {actorId}");
+                throw new InvalidOperationException("Invalid 'ApprenticeshipContractType1EarningEvent' received. Learner was null or Uln was 0.");
             }
-            catch (Exception ex)
+            var uln = message.Learner.Uln;
+            var learnerRef = message.Learner.ReferenceNumber;
+            logger.LogDebug($"Processing DataLockProxyProxyService event for learner with learner ref {learnerRef}");
+            var actorId = new ActorId(uln);
+
+            logger.LogVerbose($"Creating actor proxy for learner with learner ref {learnerRef}");
+            var actor = proxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
+            logger.LogDebug($"Actor proxy created for learner with ULN {uln}");
+
+            logger.LogVerbose($"Calling actor proxy to handle earning for learner with learner ref {learnerRef}");
+            var dataLockEvents = await actor.HandleEarning(message, CancellationToken.None).ConfigureAwait(false);
+            logger.LogDebug($"Earning handled for learner with learner ref {learnerRef}");
+
+            if (dataLockEvents != null)
             {
-                logger.LogError($"Error handling ApprenticeshipContractType1EarningEvent message. Error: {ex.Message}.", ex);
-                throw;
+                var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
+                logger.LogVerbose($"Publishing data lock event for learner with learner ref {learnerRef}: {summary}");
+                await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
+                logger.LogDebug($"Data lock event published for learner with learner ref {learnerRef}");
             }
+
+            logger.LogInfo($"Successfully processed DataLockProxyProxyService event for Actor Id {actorId}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipContractType1FunctionalSkillEarningEventHandler.cs
+++ b/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipContractType1FunctionalSkillEarningEventHandler.cs
@@ -24,40 +24,32 @@ namespace SFA.DAS.Payments.DataLocks.DataLockProxyService.Handlers
 
         public async Task Handle(Act1FunctionalSkillEarningsEvent message, IMessageHandlerContext context)
         {
-            try
+            if (message.Learner == null || message.Learner?.Uln == 0)
             {
-                if (message.Learner == null || message.Learner?.Uln == 0)
-                {
-                    throw new InvalidOperationException("Invalid 'Act1FunctionalSkillEarningsEvent' received. Learner was null or Uln was 0.");
-                }
-                var uln = message.Learner.Uln;
-                var learnerRef = message.Learner.ReferenceNumber;
-                logger.LogDebug($"Processing DataLockProxyProxyService event for learner with learner ref {learnerRef}");
-                var actorId = new ActorId(uln);
-
-                logger.LogVerbose($"Creating actor proxy for provider with learner ref {learnerRef}");
-                var actor = proxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
-                logger.LogDebug($"Actor proxy created for learner with ULN {uln}");
-
-                logger.LogVerbose($"Calling actor proxy to handle functional skill earning for learner with learner ref {learnerRef}");
-                var dataLockEvents = await actor.HandleFunctionalSkillEarning(message, CancellationToken.None).ConfigureAwait(false);
-                logger.LogDebug($"Functional skill earning handled for learner with learner ref {learnerRef}");
-
-                if (dataLockEvents != null)
-                {
-                    var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
-                    logger.LogVerbose($"Publishing functional skill data lock event for learner with learner ref {learnerRef}: {summary}");
-                    await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
-                    logger.LogDebug($"Functional Skill Data lock event published for learner with learner ref {learnerRef}");
-                }
-
-                logger.LogInfo($"Successfully processed DataLockProxyProxyService event for Actor Id {actorId}");
+                throw new InvalidOperationException("Invalid 'Act1FunctionalSkillEarningsEvent' received. Learner was null or Uln was 0.");
             }
-            catch (Exception ex)
+            var uln = message.Learner.Uln;
+            var learnerRef = message.Learner.ReferenceNumber;
+            logger.LogDebug($"Processing DataLockProxyProxyService event for learner with learner ref {learnerRef}");
+            var actorId = new ActorId(uln);
+
+            logger.LogVerbose($"Creating actor proxy for provider with learner ref {learnerRef}");
+            var actor = proxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
+            logger.LogDebug($"Actor proxy created for learner with ULN {uln}");
+
+            logger.LogVerbose($"Calling actor proxy to handle functional skill earning for learner with learner ref {learnerRef}");
+            var dataLockEvents = await actor.HandleFunctionalSkillEarning(message, CancellationToken.None).ConfigureAwait(false);
+            logger.LogDebug($"Functional skill earning handled for learner with learner ref {learnerRef}");
+
+            if (dataLockEvents != null)
             {
-                logger.LogError($"Error handling Act1FunctionalSkillEarningsEvent message. Error: {ex.Message}.", ex);
-                throw;
+                var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
+                logger.LogVerbose($"Publishing functional skill data lock event for learner with learner ref {learnerRef}: {summary}");
+                await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
+                logger.LogDebug($"Functional Skill Data lock event published for learner with learner ref {learnerRef}");
             }
+
+            logger.LogInfo($"Successfully processed DataLockProxyProxyService event for Actor Id {actorId}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipUpdatedHandler.cs
+++ b/src/SFA.DAS.Payments.DataLocks.DataLockProxyService/Handlers/ApprenticeshipUpdatedHandler.cs
@@ -24,47 +24,39 @@ namespace SFA.DAS.Payments.DataLocks.DataLockProxyService.Handlers
 
         public async Task Handle(ApprenticeshipUpdated message, IMessageHandlerContext context)
         {
-            try
+            if (message.Uln == 0)
             {
-                if (message.Uln == 0)
-                {
-                    throw new InvalidOperationException("Invalid 'ApprenticeshipUpdated' received. Uln was 0.");
-                }
-
-                logger.LogDebug($"Now handling the apprenticeship updated event.  Apprenticeship: {message.Id}, employer: {message.EmployerAccountId}, ukprn: {message.Ukprn}");
-                var actorId = new ActorId(message.Ukprn);
-                logger.LogVerbose($"Creating actor proxy.");
-                var actor = actorProxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
-                logger.LogDebug($"Actor proxy created for actor id {message.Uln}");
-                await actor.HandleApprenticeshipUpdated(message, CancellationToken.None).ConfigureAwait(false);
-
-                //var dataLockEvents = await actor.GetApprenticeshipUpdatedPayments( message, CancellationToken.None).ConfigureAwait(false);
-                //logger.LogDebug($"Earning handled for learner with learner uln {message.Uln}");
-
-                //if (dataLockEvents != null)
-                //{
-                //    var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
-                //    logger.LogVerbose($"Publishing data lock event for learner with learner uln {message.Uln}: {summary}");
-                //    await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
-                //    logger.LogDebug($"Data lock event published for learner with learner uln {message.Uln}");
-                //}
-                
-                //var dataLockFunctionalSkillEvents = await actor.GetApprenticeshipUpdateFunctionalSkillPayments(message, CancellationToken.None).ConfigureAwait(false);
-                //if (dataLockFunctionalSkillEvents != null)
-                //{
-                //    var summary = string.Join(", ", dataLockFunctionalSkillEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
-                //    logger.LogVerbose($"Publishing data lock event for learner with learner uln {message.Uln}: {summary}");
-                //    await Task.WhenAll(dataLockFunctionalSkillEvents.Select(context.Publish)).ConfigureAwait(false);
-                //    logger.LogDebug($"Data lock event published for learner with learner uln {message.Uln}");
-                //}
-                
-                logger.LogInfo($"Finished handling the apprenticeship updated event.  Apprenticeship: {message.Id}, employer: {message.EmployerAccountId}, provider: {message.Ukprn}");
+                throw new InvalidOperationException("Invalid 'ApprenticeshipUpdated' received. Uln was 0.");
             }
-            catch (Exception ex)
-            {
-                logger.LogError($"Failed to handle the apprenticeship updated event. Apprenticeship: {message.Id}, employer: {message.EmployerAccountId}, provider: {message.Ukprn}. Error: {ex}", ex);
-                throw;
-            }
+
+            logger.LogDebug($"Now handling the apprenticeship updated event.  Apprenticeship: {message.Id}, employer: {message.EmployerAccountId}, ukprn: {message.Ukprn}");
+            var actorId = new ActorId(message.Ukprn);
+            logger.LogVerbose($"Creating actor proxy.");
+            var actor = actorProxyFactory.CreateActorProxy<IDataLockService>(new Uri("fabric:/SFA.DAS.Payments.DataLocks.ServiceFabric/DataLockServiceActorService"), actorId);
+            logger.LogDebug($"Actor proxy created for actor id {message.Uln}");
+            await actor.HandleApprenticeshipUpdated(message, CancellationToken.None).ConfigureAwait(false);
+
+            //var dataLockEvents = await actor.GetApprenticeshipUpdatedPayments( message, CancellationToken.None).ConfigureAwait(false);
+            //logger.LogDebug($"Earning handled for learner with learner uln {message.Uln}");
+
+            //if (dataLockEvents != null)
+            //{
+            //    var summary = string.Join(", ", dataLockEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
+            //    logger.LogVerbose($"Publishing data lock event for learner with learner uln {message.Uln}: {summary}");
+            //    await Task.WhenAll(dataLockEvents.Select(context.Publish)).ConfigureAwait(false);
+            //    logger.LogDebug($"Data lock event published for learner with learner uln {message.Uln}");
+            //}
+                
+            //var dataLockFunctionalSkillEvents = await actor.GetApprenticeshipUpdateFunctionalSkillPayments(message, CancellationToken.None).ConfigureAwait(false);
+            //if (dataLockFunctionalSkillEvents != null)
+            //{
+            //    var summary = string.Join(", ", dataLockFunctionalSkillEvents.GroupBy(e => e.GetType().Name).Select(g => $"{g.Key}: {g.Count()}"));
+            //    logger.LogVerbose($"Publishing data lock event for learner with learner uln {message.Uln}: {summary}");
+            //    await Task.WhenAll(dataLockFunctionalSkillEvents.Select(context.Publish)).ConfigureAwait(false);
+            //    logger.LogDebug($"Data lock event published for learner with learner uln {message.Uln}");
+            //}
+                
+            logger.LogInfo($"Finished handling the apprenticeship updated event.  Apprenticeship: {message.Id}, employer: {message.EmployerAccountId}, provider: {message.Ukprn}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.EarningEvents.Domain.UnitTests/ExceptionHandlingBehaviourTests.cs
+++ b/src/SFA.DAS.Payments.EarningEvents.Domain.UnitTests/ExceptionHandlingBehaviourTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using SFA.DAS.Payments.Core;
+
+namespace SFA.DAS.Payments.EarningEvents.Domain.UnitTests
+{
+    [TestFixture]
+    public class ExceptionHandlingBehaviourTests
+    { 
+        [Test]
+        public void Test_typename_extraction()
+        {
+            var messageType = "SFA.DAS.Payments.EarningEvents.Messages.Internal.Commands.ProcessLearnerCommand, SFA.DAS.Payments.EarningEvents.Messages.Internal, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;SFA.DAS.Payments.Messages.Core.Commands.IPaymentsCommand, SFA.DAS.Payments.Messages.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;SFA.DAS.Payments.Messages.Core.IJobMessage, SFA.DAS.Payments.Messages.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;SFA.DAS.Payments.Messages.Core.Commands.ICommand, SFA.DAS.Payments.Messages.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;SFA.DAS.Payments.Messages.Core.Commands.PaymentsCommand, SFA.DAS.Payments.Messages.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;SFA.DAS.Payments.Messages.Core.IPaymentsMessage, SFA.DAS.Payments.Messages.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+            var actual = TypeString.TryParseTypeName(messageType, out var name);
+            Assert.IsTrue(actual);
+            Assert.AreEqual("ProcessLearnerCommand", name);
+        }
+    }
+}

--- a/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/CalculatedRequiredLevyAmountHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/CalculatedRequiredLevyAmountHandler.cs
@@ -37,20 +37,12 @@ namespace SFA.DAS.Payments.FundingSource.LevyFundedProxyService.Handlers
             if(!message.AccountId.HasValue)
                throw new ArgumentException($"Employer AccountId cannot be null. Event id:  {message.EventId}");
 
-            try
-            {
-                var accountToUse = levyMessageRoutingService.GetDestinationAccountId(message);
-                paymentLogger.LogDebug($"Sending levy message to levy actor: {accountToUse}.  Account: {message.AccountId}, sender: {message.TransferSenderAccountId}. ");
-                var actorId = new ActorId(accountToUse);
-                var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
-                await actor.HandleRequiredPayment(message).ConfigureAwait(false);
-                paymentLogger.LogInfo($"Successfully processed LevyFundedProxyService event for Actor Id {actorId}, Job: {message.JobId}, UKPRN: {message.Ukprn}");
-            }
-            catch (Exception ex)
-            {
-                paymentLogger.LogError($"Error while handling LevyFundedProxyService event, Job: {message.JobId}, UKPRN: {message.Ukprn}", ex);
-                throw;
-            }
+            var accountToUse = levyMessageRoutingService.GetDestinationAccountId(message);
+            paymentLogger.LogDebug($"Sending levy message to levy actor: {accountToUse}.  Account: {message.AccountId}, sender: {message.TransferSenderAccountId}. ");
+            var actorId = new ActorId(accountToUse);
+            var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
+            await actor.HandleRequiredPayment(message).ConfigureAwait(false);
+            paymentLogger.LogInfo($"Successfully processed LevyFundedProxyService event for Actor Id {actorId}, Job: {message.JobId}, UKPRN: {message.Ukprn}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/EmployerChangedProviderPriorityHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/EmployerChangedProviderPriorityHandler.cs
@@ -32,19 +32,11 @@ namespace SFA.DAS.Payments.FundingSource.LevyFundedProxyService.Handlers
         {
             paymentLogger.LogInfo($"Processing EmployerChangedProviderPriority event. Message Id: {context.MessageId}, Account Id: {message.EmployerAccountId}");
            
-            try
-            {
-                var actorId = new ActorId(message.EmployerAccountId);
-                var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
-                await actor.HandleEmployerProviderPriorityChange(message).ConfigureAwait(false);
+            var actorId = new ActorId(message.EmployerAccountId);
+            var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
+            await actor.HandleEmployerProviderPriorityChange(message).ConfigureAwait(false);
 
-                paymentLogger.LogInfo($"Successfully processed EmployerChangedProviderPriority event for Actor Id {actorId} ,Account Id: {message.EmployerAccountId}");
-            }
-            catch (Exception ex)
-            {
-                paymentLogger.LogError($"Error while handling EmployerChangedProviderPriority event, Account Id: {message.EmployerAccountId}", ex);
-                throw;
-            }
+            paymentLogger.LogInfo($"Successfully processed EmployerChangedProviderPriority event for Actor Id {actorId} ,Account Id: {message.EmployerAccountId}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/PeriodEndHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/PeriodEndHandler.cs
@@ -21,23 +21,15 @@ namespace SFA.DAS.Payments.FundingSource.LevyFundedProxyService.Handlers
 
         public async Task Handle(PeriodEndRunningEvent message, IMessageHandlerContext context)
         {
-            try
+            logger.LogInfo($"Received Period End event. Now getting employer period end commands for collection: {message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}.");
+            var employerPeriodEndCommands = await periodEndService.GenerateEmployerPeriodEndCommands(message).ConfigureAwait(false);
+            logger.LogDebug($"Got {employerPeriodEndCommands.Count} employer period end commands.");
+            foreach (var processLevyPaymentsOnMonthEndCommand in employerPeriodEndCommands)
             {
-                logger.LogInfo($"Received Period End event. Now getting employer period end commands for collection: {message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}.");
-                var employerPeriodEndCommands = await periodEndService.GenerateEmployerPeriodEndCommands(message).ConfigureAwait(false);
-                logger.LogDebug($"Got {employerPeriodEndCommands.Count} employer period end commands.");
-                foreach (var processLevyPaymentsOnMonthEndCommand in employerPeriodEndCommands)
-                {
-                    logger.LogInfo($"Sending period end command for employer '{processLevyPaymentsOnMonthEndCommand.AccountId}'");
-                    await context.SendLocal(processLevyPaymentsOnMonthEndCommand).ConfigureAwait(false);
-                }
-                logger.LogInfo($"Finished sending employer period end commands for collection: {message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}.");
+                logger.LogInfo($"Sending period end command for employer '{processLevyPaymentsOnMonthEndCommand.AccountId}'");
+                await context.SendLocal(processLevyPaymentsOnMonthEndCommand).ConfigureAwait(false);
             }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error triggering generation of levy payments for collection: {message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}");
-                throw;
-            }
+            logger.LogInfo($"Finished sending employer period end commands for collection: {message.CollectionPeriod.Period:00}-{message.CollectionPeriod.AcademicYear:0000}.");
         }
     }
 }

--- a/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/SubmissionEventHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/SubmissionEventHandler.cs
@@ -44,25 +44,17 @@ namespace SFA.DAS.Payments.FundingSource.LevyFundedProxyService.Handlers
             if (message.Ukprn == 0)
                 throw new ArgumentException($"Ukprn cannot be 0. Job Id: {message.JobId}");
 
-            try
+            logger.LogDebug($"Getting AccountId for Ukprn: {message.Ukprn}.");
+            var accountIds = await repository.GetEmployerAccountsByUkprn(message.Ukprn).ConfigureAwait(false);
+            var tasks = new List<Task>();
+            foreach (var account in accountIds)
             {
-                logger.LogDebug($"Getting AccountId for Ukprn: {message.Ukprn}.");
-                var accountIds = await repository.GetEmployerAccountsByUkprn(message.Ukprn).ConfigureAwait(false);
-                var tasks = new List<Task>();
-                foreach (var account in accountIds)
-                {
-                    var accountToUse = levyMessageRoutingService.GetDestinationAccountId(account.Item1, account.Item2);
-                    tasks.Add(InvokeSubmissionAction(accountToUse, message));
-                }
+                var accountToUse = levyMessageRoutingService.GetDestinationAccountId(account.Item1, account.Item2);
+                tasks.Add(InvokeSubmissionAction(accountToUse, message));
+            }
 
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-                logger.LogInfo($"Successfully processed {messageType} for Job: {message.JobId}, UKPRN: {message.Ukprn}. Skipped submission removing as no account ID found.");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error while handling {messageType} event. Error: {ex.Message}, Job: {message.JobId}, UKPRN: {message.Ukprn}", ex);
-                throw;
-            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            logger.LogInfo($"Successfully processed {messageType} for Job: {message.JobId}, UKPRN: {message.Ukprn}. Skipped submission removing as no account ID found.");
         }
 
         private async Task InvokeSubmissionAction(long accountId, T message)

--- a/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/UnableToFundTransferFundingSourcePaymentEventHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.LevyFundedProxyService/Handlers/UnableToFundTransferFundingSourcePaymentEventHandler.cs
@@ -33,21 +33,12 @@ namespace SFA.DAS.Payments.FundingSource.LevyFundedProxyService.Handlers
             if (!message.AccountId.HasValue)
                 throw new ArgumentException($"Employer AccountId cannot be null. Event Id: {message.EventId}");
 
-            try
-            {
-                logger.LogDebug($"Sending message to actor: {message.AccountId.Value}.");
-                var actorId = new ActorId(message.AccountId.Value);
-                var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
-                var fundingSourceEvents = await actor.UnableToFundTransfer(message).ConfigureAwait(false);
-                await Task.WhenAll(fundingSourceEvents.Select(context.Publish));
-                logger.LogInfo($"Successfully processed ProcessUnableToFundTransferFundingSourcePayment event for Actor Id {actorId}, Learner: {message.Learner?.ReferenceNumber}, Job: {message.JobId}, UKPRN: {message.Ukprn}");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error while handling ProcessUnableToFundTransferFundingSourcePayment event. Error: {ex.Message}, Event Id: {message.EventId}, Learner: {message.Learner?.ReferenceNumber}, Job: {message.JobId}, UKPRN: {message.Ukprn}", ex);
-                throw;
-            }
-
+            logger.LogDebug($"Sending message to actor: {message.AccountId.Value}.");
+            var actorId = new ActorId(message.AccountId.Value);
+            var actor = proxyFactory.CreateActorProxy<ILevyFundedService>(new Uri("fabric:/SFA.DAS.Payments.FundingSource.ServiceFabric/LevyFundedServiceActorService"), actorId);
+            var fundingSourceEvents = await actor.UnableToFundTransfer(message).ConfigureAwait(false);
+            await Task.WhenAll(fundingSourceEvents.Select(context.Publish));
+            logger.LogInfo($"Successfully processed ProcessUnableToFundTransferFundingSourcePayment event for Actor Id {actorId}, Learner: {message.Learner?.ReferenceNumber}, Job: {message.JobId}, UKPRN: {message.Ukprn}");
         }
     }
 }

--- a/src/SFA.DAS.Payments.FundingSource.NonLevyFundedService/Handlers/CalculatedRequiredCoInvestedAmountEventHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.NonLevyFundedService/Handlers/CalculatedRequiredCoInvestedAmountEventHandler.cs
@@ -29,30 +29,22 @@ namespace SFA.DAS.Payments.FundingSource.NonLevyFundedService.Handlers
             var currentExecutionContext = (ESFA.DC.Logging.ExecutionContext)executionContext;
             currentExecutionContext.JobId = message.JobId.ToString();
 
-            try
+            var payments = contractType2RequiredPaymentService.GetFundedPayments(message);
+            foreach (var recordablePaymentEvent in payments)
             {
-                var payments = contractType2RequiredPaymentService.GetFundedPayments(message);
-                foreach (var recordablePaymentEvent in payments)
+                try
                 {
-                    try
-                    {
-                        await context.Publish(recordablePaymentEvent);
-                        paymentLogger.LogInfo($"Successfully published CoInvestedPayment of Type  {recordablePaymentEvent.GetType().Name}");
-                    }
-                    catch (Exception ex)
-                    {
-                        paymentLogger.LogError($"Error publishing the event: RecordablePaymentEvent", ex);
-                        throw;
-                    }
+                    await context.Publish(recordablePaymentEvent);
+                    paymentLogger.LogInfo($"Successfully published CoInvestedPayment of Type  {recordablePaymentEvent.GetType().Name}");
                 }
+                catch (Exception ex)
+                {
+                    paymentLogger.LogError($"Error publishing the event: RecordablePaymentEvent", ex);
+                    throw;
+                }
+            }
 
-                paymentLogger.LogInfo($"Successfully processed NonLevyFunded Service event for Job Id {message.JobId}");
-            }
-            catch (Exception ex)
-            {
-                paymentLogger.LogError($"Error while handling NonLevyFundedService event", ex);
-                throw;
-            }
+            paymentLogger.LogInfo($"Successfully processed NonLevyFunded Service event for Job Id {message.JobId}");
 
         }
     }

--- a/src/SFA.DAS.Payments.FundingSource.NonLevyFundedService/Handlers/CalculatedRequiredIncentiveAmountEventHandler.cs
+++ b/src/SFA.DAS.Payments.FundingSource.NonLevyFundedService/Handlers/CalculatedRequiredIncentiveAmountEventHandler.cs
@@ -25,20 +25,12 @@ namespace SFA.DAS.Payments.FundingSource.NonLevyFundedService.Handlers
 
         public async Task Handle(CalculatedRequiredIncentiveAmount message, IMessageHandlerContext context)
         {
-            try
-            {
-                logger.LogDebug($"Now processing the incentive required payment event.  Ukprn: {message.Ukprn}, Learner ref: {message.Learner.ReferenceNumber}, Job id: {message.JobId}, Amount: {message.AmountDue}, Incentive type: {message.Type}.");
-                var currentExecutionContext = (ESFA.DC.Logging.ExecutionContext)executionContext;
-                currentExecutionContext.JobId = message.JobId.ToString();
-                var sfaFullyFundedPayment = incentiveProcessor.Process(message);
-                await context.Publish(sfaFullyFundedPayment);
-                logger.LogInfo($"Finished processing the incentive required payment event.  Ukprn: {message.Ukprn}, Learner ref: {message.Learner.ReferenceNumber}, Job id: {message.JobId}, Amount: {message.AmountDue}, Incentive type: {message.Type}.");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error while trying build sfa fully funded funding source payment.  Error: {ex.Message}.", ex);
-                throw;
-            }
+            logger.LogDebug($"Now processing the incentive required payment event.  Ukprn: {message.Ukprn}, Learner ref: {message.Learner.ReferenceNumber}, Job id: {message.JobId}, Amount: {message.AmountDue}, Incentive type: {message.Type}.");
+            var currentExecutionContext = (ESFA.DC.Logging.ExecutionContext)executionContext;
+            currentExecutionContext.JobId = message.JobId.ToString();
+            var sfaFullyFundedPayment = incentiveProcessor.Process(message);
+            await context.Publish(sfaFullyFundedPayment);
+            logger.LogInfo($"Finished processing the incentive required payment event.  Ukprn: {message.Ukprn}, Learner ref: {message.Learner.ReferenceNumber}, Job id: {message.JobId}, Amount: {message.AmountDue}, Incentive type: {message.Type}.");
         }
     }
 }

--- a/src/SFA.DAS.Payments.Monitoring.JobsProxyService/Handlers/RecordEarningsJobHandler.cs
+++ b/src/SFA.DAS.Payments.Monitoring.JobsProxyService/Handlers/RecordEarningsJobHandler.cs
@@ -23,16 +23,8 @@ namespace SFA.DAS.Payments.Monitoring.JobsProxyService.Handlers
 
         public async Task Handle(RecordEarningsJob message, IMessageHandlerContext context)
         {
-            try
-            {
-                logger.LogVerbose($"Getting actor for job: {message.JobId}");
-                var actorId = new ActorId(message.JobId.ToString());
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning($"Failed to record earnings job. ukprn: {message.Ukprn}, Job id: {message.JobId}, Period: {message.CollectionPeriod}-{message.CollectionYear}  Error: {ex.Message}",ex);
-                throw;
-            }
+            logger.LogVerbose($"Getting actor for job: {message.JobId}");
+            var actorId = new ActorId(message.JobId.ToString());
         }
     }
 }

--- a/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/FundingSourcePaymentEventHandler.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/FundingSourcePaymentEventHandler.cs
@@ -40,25 +40,18 @@ namespace SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService.Handlers
 
         public async Task Handle(FundingSourcePaymentEvent message, IMessageHandlerContext context)
         {
-            try
-            {
-                paymentLogger.LogDebug($"Processing Funding Source Payment Event for Message Id : {context.MessageId}");
-                var paymentModel = mapper.Map<ProviderPaymentEventModel>(message);
-                await paymentsService.ProcessPayment(paymentModel, default(CancellationToken)).ConfigureAwait(false);
+            paymentLogger.LogDebug($"Processing Funding Source Payment Event for Message Id : {context.MessageId}");
+            var paymentModel = mapper.Map<ProviderPaymentEventModel>(message);
+            await paymentsService.ProcessPayment(paymentModel, default(CancellationToken)).ConfigureAwait(false);
 
-                var afterMonthEndPayment = await afterMonthEndPaymentService.GetPaymentEvent(message);
-                if (afterMonthEndPayment != null)
-                {
-                    paymentLogger.LogInfo($"Sent {afterMonthEndPayment.GetType().Name} for {message.JobId} and Message Type {message.GetType().Name}");
-                    paymentLogger.LogDebug($"Sending Provider Payment Event {JsonConvert.SerializeObject(afterMonthEndPayment)} for Message Id : {context.MessageId}.  {message.ToDebug()}");
-                    await context.Publish(afterMonthEndPayment).ConfigureAwait(false);
-                }
-            }
-            catch (Exception ex)
+            var afterMonthEndPayment = await afterMonthEndPaymentService.GetPaymentEvent(message);
+            if (afterMonthEndPayment != null)
             {
-                paymentLogger.LogError($"Error handling payment. Ukprn: {message.Ukprn}, JobId: {message.JobId}, Learner: {message.Learner.ReferenceNumber}, ContractType: {message.ContractType:G}, Transaction Type: {message.TransactionType:G}.  Error: {ex}", ex);
-                throw;
+                paymentLogger.LogInfo($"Sent {afterMonthEndPayment.GetType().Name} for {message.JobId} and Message Type {message.GetType().Name}");
+                paymentLogger.LogDebug($"Sending Provider Payment Event {JsonConvert.SerializeObject(afterMonthEndPayment)} for Message Id : {context.MessageId}.  {message.ToDebug()}");
+                await context.Publish(afterMonthEndPayment).ConfigureAwait(false);
             }
+
             paymentLogger.LogDebug($"Finished processing Funding Source Payment Event for Message Id : {context.MessageId}.  {message.ToDebug()}");
         }
     }

--- a/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/IlrSubmittedEventHandler.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/IlrSubmittedEventHandler.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService.Handlers
 {
     public class IlrSubmittedEventHandler : IHandleMessages<ReceivedProviderEarningsEvent>
     {
-
         private readonly IPaymentLogger logger;
         private readonly IHandleIlrSubmissionService handleIlrSubmissionService;
         private readonly IExecutionContext executionContext;
@@ -28,21 +27,13 @@ namespace SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService.Handlers
 
         public async Task Handle(ReceivedProviderEarningsEvent message, IMessageHandlerContext context)
         {
-            try
-            {
-                var currentExecutionContext = (ESFA.DC.Logging.ExecutionContext)executionContext;
-                currentExecutionContext.JobId = message.JobId.ToString();
-                logger.LogDebug(
-                    $"Processing Ilr Submitted Event for Message: {message.ToJson()}.");
-                await handleIlrSubmissionService.Handle(message, CancellationToken.None);
-                logger.LogInfo($"Successfully processed Ilr Submitted Event: {message.ToJson()}");
-                await context.Reply(0).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error handling the ILR submitted event. Ex: {ex.Message}", ex);
-                throw;
-            }
+            var currentExecutionContext = (ESFA.DC.Logging.ExecutionContext)executionContext;
+            currentExecutionContext.JobId = message.JobId.ToString();
+            logger.LogDebug(
+                $"Processing Ilr Submitted Event for Message: {message.ToJson()}.");
+            await handleIlrSubmissionService.Handle(message, CancellationToken.None);
+            logger.LogInfo($"Successfully processed Ilr Submitted Event: {message.ToJson()}");
+            await context.Reply(0).ConfigureAwait(false);
         }
     }
 }

--- a/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/SubmissionEventHandler.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService/Handlers/SubmissionEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NServiceBus;
 using SFA.DAS.Payments.Application.Infrastructure.Logging;
@@ -8,7 +8,7 @@ using SFA.DAS.Payments.ProviderPayments.Application.Services;
 
 namespace SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService.Handlers
 {
-    public abstract class SubmissionEventHandler<T> : IHandleMessages<T> 
+    public abstract class SubmissionEventHandler<T> : IHandleMessages<T>
         where T: SubmissionEvent
     {
         private readonly IPaymentLogger paymentLogger;
@@ -25,17 +25,9 @@ namespace SFA.DAS.Payments.ProviderPayments.ProviderPaymentsService.Handlers
         {
             var messageType = message.GetType().Name;
 
-            try
-            {
-                paymentLogger.LogDebug($"Processing {messageType} for Message Id : {context.MessageId}");
+            paymentLogger.LogDebug($"Processing {messageType} for Message Id : {context.MessageId}");
 
-                await HandleSubmission(message, submissionService);
-            }
-            catch (Exception ex)
-            {
-                paymentLogger.LogError($"Error while handling {messageType}. Error: {ex.Message}, Job: {message.JobId}, UKPRN: {message.Ukprn}", ex);
-                throw;
-            }
+            await HandleSubmission(message, submissionService);
 
             paymentLogger.LogDebug($"Finished processing {messageType} for Message Id : {context.MessageId}. ");
         }

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/EarningEventHandlerBase.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/EarningEventHandlerBase.cs
@@ -1,4 +1,4 @@
-﻿using ESFA.DC.Logging.Interfaces;
+using ESFA.DC.Logging.Interfaces;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Client;
 using NServiceBus;
@@ -41,58 +41,33 @@ namespace SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService.Handler
             paymentLogger.LogInfo($"Processing RequiredPaymentsProxyService event. Message Id : {context.MessageId}");
             executionContext.JobId = message.JobId.ToString();
 
-            try
-            {
-                var contractType = message is PayableEarningEvent ? ContractType.Act1 :
-                    message is ApprenticeshipContractType2EarningEvent ? ContractType.Act2 :
-                    (message as IFunctionalSkillEarningEvent)?.ContractType 
-                    ?? throw new InvalidOperationException($"Cannot resolve contract type for {typeof(T).FullName}");
+            var contractType = message is PayableEarningEvent ? ContractType.Act1 :
+                message is ApprenticeshipContractType2EarningEvent ? ContractType.Act2 :
+                (message as IFunctionalSkillEarningEvent)?.ContractType
+                ?? throw new InvalidOperationException($"Cannot resolve contract type for {typeof(T).FullName}");
 
-                var key = apprenticeshipKeyService.GenerateApprenticeshipKey(
-                    message.Ukprn,
-                    message.Learner.ReferenceNumber,
-                    message.LearningAim.FrameworkCode,
-                    message.LearningAim.PathwayCode,
-                    message.LearningAim.ProgrammeType,
-                    message.LearningAim.StandardCode,
-                    message.LearningAim.Reference,
-                    message.CollectionPeriod.AcademicYear,
-                    contractType
-                );
+            var key = apprenticeshipKeyService.GenerateApprenticeshipKey(
+                message.Ukprn,
+                message.Learner.ReferenceNumber,
+                message.LearningAim.FrameworkCode,
+                message.LearningAim.PathwayCode,
+                message.LearningAim.ProgrammeType,
+                message.LearningAim.StandardCode,
+                message.LearningAim.Reference,
+                message.CollectionPeriod.AcademicYear,
+                contractType
+            );
 
-                var actorId = new ActorId(key);
-                var actor = proxyFactory.CreateActorProxy<IRequiredPaymentsService>(new Uri("fabric:/SFA.DAS.Payments.RequiredPayments.ServiceFabric/RequiredPaymentsServiceActorService"), actorId);
-                IReadOnlyCollection<PeriodisedRequiredPaymentEvent> requiredPaymentEvent;
-                try
-                {
-                    requiredPaymentEvent = await HandleEarningEvent(message, actor).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    paymentLogger.LogError($"Error invoking required payments actor. Error: {ex.Message}", ex);
-                    throw;
-                }
+            var actorId = new ActorId(key);
+            var actor = proxyFactory.CreateActorProxy<IRequiredPaymentsService>(new Uri("fabric:/SFA.DAS.Payments.RequiredPayments.ServiceFabric/RequiredPaymentsServiceActorService"), actorId);
+            IReadOnlyCollection<PeriodisedRequiredPaymentEvent> requiredPaymentEvent;
 
-                try
-                {
-                    if (requiredPaymentEvent != null)
-                        await Task.WhenAll(requiredPaymentEvent.Select(context.Publish)).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    //TODO: add more details when we flesh out the event.
-                    paymentLogger.LogError($"Error publishing the event: 'RequiredPaymentEvent'.  Error: {ex.Message}.", ex);
-                    throw;
-                    //TODO: update the job
-                }
+            requiredPaymentEvent = await HandleEarningEvent(message, actor).ConfigureAwait(false);
 
-                paymentLogger.LogInfo($"Successfully processed RequiredPaymentsProxyService event for Actor Id {actorId}");
-            }
-            catch (Exception ex)
-            {
-                paymentLogger.LogError("Error while handling RequiredPaymentsProxyService event", ex);
-                throw;
-            }
+            if (requiredPaymentEvent != null)
+                await Task.WhenAll(requiredPaymentEvent.Select(context.Publish)).ConfigureAwait(false);
+
+            paymentLogger.LogInfo($"Successfully processed RequiredPaymentsProxyService event for Actor Id {actorId}");
         }
 
         protected abstract Task<ReadOnlyCollection<PeriodisedRequiredPaymentEvent>> HandleEarningEvent(T message, IRequiredPaymentsService actor);

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/IdentifiedRemovedLearningAimHandler.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/IdentifiedRemovedLearningAimHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -35,32 +35,24 @@ namespace SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService.Handler
             logger.LogDebug($"Processing 'IdentifiedRemovedLearningAim' message.");
             ((ExecutionContext)executionContext).JobId = message.JobId.ToString();
 
-            try
-            {
-                var key = apprenticeshipKeyService.GenerateApprenticeshipKey(
-                    message.Ukprn,
-                    message.Learner.ReferenceNumber,
-                    message.LearningAim.FrameworkCode,
-                    message.LearningAim.PathwayCode,
-                    message.LearningAim.ProgrammeType,
-                    message.LearningAim.StandardCode,
-                    message.LearningAim.Reference,
-                    message.CollectionPeriod.AcademicYear, 
-                    message.ContractType);
+            var key = apprenticeshipKeyService.GenerateApprenticeshipKey(
+                message.Ukprn,
+                message.Learner.ReferenceNumber,
+                message.LearningAim.FrameworkCode,
+                message.LearningAim.PathwayCode,
+                message.LearningAim.ProgrammeType,
+                message.LearningAim.StandardCode,
+                message.LearningAim.Reference,
+                message.CollectionPeriod.AcademicYear,
+                message.ContractType);
 
-                var actorId = new ActorId(key);
-                var actor = proxyFactory.CreateActorProxy<IRequiredPaymentsService>(new Uri("fabric:/SFA.DAS.Payments.RequiredPayments.ServiceFabric/RequiredPaymentsServiceActorService"), actorId);
-                IReadOnlyCollection<PeriodisedRequiredPaymentEvent> requiredPayments = await actor.RefundRemovedLearningAim(message, CancellationToken.None).ConfigureAwait(false);
-                logger.LogDebug($"Got {requiredPayments?.Count ?? 0} required payments.");
-                if (requiredPayments != null)
-                    await Task.WhenAll(requiredPayments.Select(context.Publish)).ConfigureAwait(false);
-                logger.LogInfo($"Successfully processed IdentifiedRemovedLearningAim event for Actor Id {actorId}");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"Error while handling IdentifiedRemovedLearningAim event. Error: {ex.Message}", ex);
-                throw;
-            }
+            var actorId = new ActorId(key);
+            var actor = proxyFactory.CreateActorProxy<IRequiredPaymentsService>(new Uri("fabric:/SFA.DAS.Payments.RequiredPayments.ServiceFabric/RequiredPaymentsServiceActorService"), actorId);
+            IReadOnlyCollection<PeriodisedRequiredPaymentEvent> requiredPayments = await actor.RefundRemovedLearningAim(message, CancellationToken.None).ConfigureAwait(false);
+            logger.LogDebug($"Got {requiredPayments?.Count ?? 0} required payments.");
+            if (requiredPayments != null)
+                await Task.WhenAll(requiredPayments.Select(context.Publish)).ConfigureAwait(false);
+            logger.LogInfo($"Successfully processed IdentifiedRemovedLearningAim event for Actor Id {actorId}");
         }
     }
 }


### PR DESCRIPTION
Improve the signal-to-noise ratio in the logs in order to see bone-fide errors with message processing.  Currently each and every message failure is logged as an Error, even if the message succeeds on a subsequent retry.

[NServiceBus' default behaviour](https://docs.particular.net/nservicebus/recoverability/#retry-logging) is to log all failures at level Warn, with only the final failure logged at level Error.  We have an NServiceBus behaviour that independently logs all failures as Error, and it seems to be this behaviour that is causing our Too Much Information problem.

As a first step we are going to remove this behaviour and revert to NServiceBus' default.  This drops the number of `Error` logs per actually-failed message from 24 to 1.