### PR TITLE
PV2-1903-Fix-EventTime-in-RecordedAct1CompletionPayment

### DIFF
--- a/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ProviderPaymentsProfile.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ProviderPaymentsProfile.cs
@@ -129,6 +129,8 @@ namespace SFA.DAS.Payments.ProviderPayments.Application.Mapping
             CreateMap<TransferFundingSourcePaymentEvent, TransferProviderPaymentEvent>();
 
             CreateMap<PaymentModel, RecordedAct1CompletionPayment>()
+                .ForMember(dest => dest.EventId, opt => opt.UseValue(Guid.NewGuid()))
+                .ForMember(dest => dest.EventTime, opt => opt.UseValue(DateTimeOffset.UtcNow))
                 .ForMember(dest => dest.Ukprn, opt => opt.MapFrom(source => source.Ukprn))
                 .ForMember(dest => dest.DeliveryPeriod, opt => opt.MapFrom(source => source.DeliveryPeriod))
                 .ForMember(dest => dest.CollectionPeriod, opt => opt.ResolveUsing(src => CollectionPeriodFactory.CreateFromAcademicYearAndPeriod(src.CollectionPeriod.AcademicYear, src.CollectionPeriod.Period)))

--- a/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ProviderPaymentsProfile.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ProviderPaymentsProfile.cs
@@ -129,8 +129,8 @@ namespace SFA.DAS.Payments.ProviderPayments.Application.Mapping
             CreateMap<TransferFundingSourcePaymentEvent, TransferProviderPaymentEvent>();
 
             CreateMap<PaymentModel, RecordedAct1CompletionPayment>()
-                .ForMember(dest => dest.EventId, opt => opt.UseValue(Guid.NewGuid()))
-                .ForMember(dest => dest.EventTime, opt => opt.UseValue(DateTimeOffset.UtcNow))
+                .ForMember(dest => dest.EventId, opt => opt.MapFrom(source => Guid.NewGuid()))
+                .ForMember(dest => dest.EventTime, opt => opt.MapFrom(source => DateTimeOffset.UtcNow))
                 .ForMember(dest => dest.Ukprn, opt => opt.MapFrom(source => source.Ukprn))
                 .ForMember(dest => dest.DeliveryPeriod, opt => opt.MapFrom(source => source.DeliveryPeriod))
                 .ForMember(dest => dest.CollectionPeriod, opt => opt.ResolveUsing(src => CollectionPeriodFactory.CreateFromAcademicYearAndPeriod(src.CollectionPeriod.AcademicYear, src.CollectionPeriod.Period)))

--- a/src/SFA.DAS.Payments.ProviderPayments.Messages/RecordedAct1CompletionPayment.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Messages/RecordedAct1CompletionPayment.cs
@@ -8,8 +8,8 @@ namespace SFA.DAS.Payments.ProviderPayments.Messages
     public class RecordedAct1CompletionPayment : IPaymentsEvent
     {
         public long JobId { get;  }
-        public Guid EventId { get; } = Guid.NewGuid();
-        public DateTimeOffset EventTime { get; } = DateTimeOffset.UtcNow;
+        public Guid EventId { get; set; }
+        public DateTimeOffset EventTime { get; set; }
         public long Ukprn { get; set; }
         public Learner Learner { get; set; }
         public LearningAim LearningAim { get; set; }


### PR DESCRIPTION
keep Event class as  Simple POCO, and use automapper so that if we change the implementation for EventId or EventTime the consumers are not affected by our implementation