### PR TITLE
GetEmployerCoInvestedPaymentHistoryTotal - trim decimal points after sum

### DIFF
--- a/src/SFA.DAS.Payments.RequiredPayments.Application/Repositories/PaymentHistoryRepository.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.Application/Repositories/PaymentHistoryRepository.cs
@@ -79,7 +79,7 @@ namespace SFA.DAS.Payments.RequiredPayments.Application.Repositories
 
         public async Task<decimal> GetEmployerCoInvestedPaymentHistoryTotal(ApprenticeshipKey apprenticeshipKey, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await dataContext.Payment
+            var decimalSumOfAmount = await dataContext.Payment
                 .Where(payment => apprenticeshipKey.Ukprn == payment.Ukprn &&
                                   apprenticeshipKey.FrameworkCode == payment.LearningAimFrameworkCode &&
                                   apprenticeshipKey.LearnAimRef == payment.LearningAimReference &&
@@ -89,12 +89,13 @@ namespace SFA.DAS.Payments.RequiredPayments.Application.Repositories
                                   apprenticeshipKey.StandardCode == payment.LearningAimStandardCode &&
                                   apprenticeshipKey.ContractType == payment.ContractType &&
                                   payment.TransactionType == TransactionType.Learning &&
-                                  payment.FundingSource == FundingSourceType.CoInvestedEmployer
-                                  )
-                //NOTE: do not remove cast to (int) this is used to remove decimal places from expectedContribution Amount i.e. 123.9997 becomes 123
-                .Select(payment => (int)payment.Amount)
+                                  payment.FundingSource == FundingSourceType.CoInvestedEmployer)
+                .Select(payment => payment.Amount)
                 .DefaultIfEmpty(0)
                 .SumAsync(cancellationToken);
+
+            //NOTE: do not remove cast to (int) this is used to remove decimal places from expectedContribution Amount i.e. 123.9997 becomes 123
+            return (int)decimalSumOfAmount;
         }
 
         public async Task<List<IdentifiedRemovedLearningAim>> IdentifyRemovedLearnerAims(short academicYear, byte collectionPeriod, long ukprn, DateTime ilrSubmissionDateTime, CancellationToken cancellationToken)


### PR DESCRIPTION
Apply recommended fix to drop decimal points only after individual payment amounts are summed.