### PR TITLE
PV2-3430 - ScheduledJobs -Keep FundingSource records where FundingPlatform = 2 (DigitalApprenticeshipService).

### DIFF
--- a/src/SFA.DAS.Payments.ScheduledJobs/AuditDataCleanUp/AuditDataCleanUpService.cs
+++ b/src/SFA.DAS.Payments.ScheduledJobs/AuditDataCleanUp/AuditDataCleanUpService.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
-using NServiceBus;
 using Microsoft.EntityFrameworkCore;
+using NServiceBus;
 using SFA.DAS.Payments.Application.Infrastructure.Logging;
 using SFA.DAS.Payments.Application.Messaging;
 using SFA.DAS.Payments.Application.Repositories;
@@ -152,8 +152,8 @@ namespace SFA.DAS.Payments.ScheduledJobs.AuditDataCleanUp
         private async Task DeleteFundingSourceEvent(IList<SqlParameter> sqlParameters, string sqlParamName, string paramValues)
         {
             var fundingSourceEventCount = await dataContext.Database.ExecuteSqlCommandAsync(
-                    $"DELETE Payments2.FundingSourceEvent WHERE JobId IN ({sqlParamName})",
-                    sqlParameters);
+                $"DELETE Payments2.FundingSourceEvent WHERE JobId IN ({sqlParamName}) AND Payments2.FundingSourceEvent.FundingPlatformType != '2' ",
+                sqlParameters);
 
             paymentLogger.LogInfo($"DELETED {fundingSourceEventCount} FundingSourceEvents for JobIds {paramValues}");
         }


### PR DESCRIPTION
Test approach:

- Run ScheduledJobs locally
- Find 2 records with matching JobId's, change one record to use FundingPlatform = 2
- Add the following message to `sfa-das-payments-ScheduledJobs-FundingSource` queue
```
{
    "jobsToBeDeleted": [
      {
      "dcJobId": 171106
      }
    ]
}
```

-Ensure only non FundingSource=2 record is deleted.

Pre-run
![image](https://github.com/user-attachments/assets/972f101a-4cfb-4f14-9468-b8b3bbdd4f83)


Post-run
![image](https://github.com/user-attachments/assets/84c52edd-383a-46ad-baae-73e21a4e4d93)
