### PR TITLE
Pv2 3642 at clawback for learner withdrawn before 42 days

### DIFF
--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Data/Training.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Data/Training.cs
@@ -1,4 +1,5 @@
 ﻿using SFA.DAS.Payments.Model.Core.Entities;
+using System;
 using TechTalk.SpecFlow.Assist.Attributes;
 
 namespace SFA.DAS.Payments.AcceptanceTests.Core.Data
@@ -9,8 +10,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Data
         public string LearnerId { get; set; }
         public long Uln { get; set; }
         public string StartDate { get; set; }
-        public string TotalTrainingPriceEffectiveDate {  get; set; }
-        public string  TotalAssessmentPriceEffectiveDate { get; set; }
+        public string TotalTrainingPriceEffectiveDate { get; set; }
+        public string TotalAssessmentPriceEffectiveDate { get; set; }
         public string PlannedDuration { get; set; }
         public decimal TotalTrainingPrice { get; set; }
         public decimal TotalAssessmentPrice { get; set; }
@@ -21,8 +22,23 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Data
         public decimal? AgreedPrice => TotalTrainingPrice + TotalAssessmentPrice;
         public decimal? InstallmentAmount => (AgreedPrice * 0.8M) / NumberOfInstallments;
         public decimal? CompletionAmount => AgreedPrice * 0.2M;
-        public int NumberOfInstallments => int.Parse(PlannedDuration.Replace("months", null).Trim());
-        public int ActualInstallments => string.IsNullOrEmpty(ActualDuration) ? 0 : int.Parse(ActualDuration.Replace("months", null).Trim());
+        public int NumberOfInstallments
+        {
+            get
+            {
+                if (!PlannedDuration.Contains("days"))
+                {
+                    return int.Parse(PlannedDuration.Replace("months", null).Trim());
+                }
+
+                var days = int.Parse(PlannedDuration.Replace("days", null).Trim());
+
+                //if the planned duration is less than or equal to 42 days then 1 installment otherwise 1 installment per month
+                return days <= 42 ? 1 : Math.Max((int)Math.Ceiling(days / 30.0), 1);
+            }
+        }
+
+        public int ActualInstallments => int.Parse(ActualDuration.Replace("months", null).Trim());
         public decimal? BalancingPayment { get; set; } // TODO: populate properly
         public ContractType ContractType { get; set; }
         public int AimSequenceNumber { get; set; }
@@ -33,7 +49,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core.Data
         public int PathwayCode { get; set; }
 
         [TableAliases("[E|e]mployer [C|c]ontribution")]
-        public int? Pmr { get; set; } 
+        public int? Pmr { get; set; }
         [TableAliases("Exemption Code")]
         public int CompletionHoldBackExemptionCode { get; set; }
 

--- a/src/SFA.DAS.Payments.AcceptanceTests.Core/Extensions.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.Core/Extensions.cs
@@ -51,7 +51,13 @@ namespace SFA.DAS.Payments.AcceptanceTests.Core
             var regex = new Regex("[ ]{2,}", options);
             var cleanStr = regex.Replace(duration, " ");
 
+            
             var durationElements = cleanStr.Split(' ');
+
+            if (!durationElements.Contains("-") && Array.Exists(durationElements, x=>x.Contains("days")))
+            {
+                return startDate.ToDate().AddDays(int.Parse(durationElements[0])) - startDate.ToDate();
+            }
 
             if (Array.Exists(durationElements, x => x.Contains("month")))
             {

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/SFA.DAS.Payments.AcceptanceTests.EndToEnd.csproj
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/SFA.DAS.Payments.AcceptanceTests.EndToEnd.csproj
@@ -1552,6 +1552,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Two Non-Levy Learners Finish On Time PV2-337.feature</DependentUpon>
     </Compile>
+    <Compile Include="Tests\Non-Levy Learner - Refunds\Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature.cs">
+      <DependentUpon>Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
     <Compile Include="Tests\Non-Levy Learner\Employer Change of CIrcumstances\Change employer at end of month PV2-381.feature.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -1751,6 +1756,11 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Levy learner changes start date forwards in month - PV2-280.feature</DependentUpon>
+    </Compile>
+    <Compile Include="Tests\Refunds\Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature.cs">
+      <DependentUpon>Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="Tests\Refunds\PV2-252 - Levy learner insufficient levy available to cover full payments provider retrospectively notifies of a withdrawal.feature.cs">
       <AutoGen>True</AutoGen>
@@ -2751,6 +2761,10 @@
       <Generator>SpecFlowSingleFileGenerator</Generator>
       <LastGenOutput>Two Non-Levy Learners Finish On Time PV2-337.feature.cs</LastGenOutput>
     </None>
+    <None Include="Tests\Non-Levy Learner - Refunds\Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature.cs</LastGenOutput>
+    </None>
     <None Include="Tests\Non-Levy Learner\Employer Change of CIrcumstances\Change employer at end of month PV2-381.feature">
       <Generator>SpecFlowSingleFileGenerator</Generator>
       <LastGenOutput>Change employer at end of month PV2-381.feature.cs</LastGenOutput>
@@ -2910,6 +2924,10 @@
     <None Include="Tests\Refunds\Levy learner changes start date forwards in month - PV2-280.feature">
       <Generator>SpecFlowSingleFileGenerator</Generator>
       <LastGenOutput>Levy learner changes start date forwards in month - PV2-280.feature.cs</LastGenOutput>
+    </None>
+    <None Include="Tests\Refunds\Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature.cs</LastGenOutput>
     </None>
     <None Include="Tests\Refunds\PV2-252 - Levy learner insufficient levy available to cover full payments provider retrospectively notifies of a withdrawal.feature">
       <Generator>SpecFlowSingleFileGenerator</Generator>

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Non-Levy Learner - Refunds/Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Non-Levy Learner - Refunds/Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
@@ -54,10 +54,10 @@ Scenario:  Provider retrospectively notifies of a withdrawal before 42 days for 
         | Jul/Current Academic Year | 0            | 0          | 0         | pe-1                     |
     And only the following payments will be calculated
         | Collection Period         | Delivery Period           | On-Programme | Completion | Balancing |
-        | R02/Current Academic Year | Aug/Current Academic Year | -750         | 0          | 0         |
+        | R06/Current Academic Year | Aug/Current Academic Year | -750         | 0          | 0         |
     And only the following provider payments will be recorded
         | Collection Period         | Delivery Period           | SFA Co-Funded Payments | Employer Co-Funded Payments | Transaction Type |
-        | R02/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |
+        | R06/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |
     And at month end only the following provider payments will be generated
         | Collection Period         | Delivery Period           | SFA Co-Funded Payments | Employer Co-Funded Payments | Transaction Type |
-        | R02/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |
+        | R06/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Non-Levy Learner - Refunds/Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Non-Levy Learner - Refunds/Non-levy learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
@@ -1,0 +1,63 @@
+﻿@basic_refund
+@supports_dc_e2e
+Feature: Non-levy learner provider retrospectively notifies a withdrawal before 42 days- PV2-3642
+	As a provider,
+	I want a Non-levy learner, where the provider retrospectively notifies a withdrawal before 42 days and previously paid monthly instalments are refunded
+	So that I am accurately paid my apprenticeship provision.
+
+
+Scenario:  Provider retrospectively notifies of a withdrawal before 42 days for a non-levy learner after payments have already been made PV2-3642
+    Given the provider previously submitted the following learner details
+        | Priority | Start Date             | Planned Duration | Total Training Price | Total Training Price Effective Date | Total Assessment Price | Total Assessment Price Effective Date | Actual Duration | Completion Status | SFA Contribution Percentage | Contract Type | Aim Sequence Number | Aim Reference | Framework Code | Pathway Code | Programme Type | Funding Line Type                               |
+        | 1        | start of academic year | 12 months        | 11250                | Aug/Current Academic Year           | 0                      | Aug/Current Academic Year             |                 | continuing        | 90%                         | Act2          | 1                   | ZPROG001      | 593            | 1            | 20             | 19+ Apprenticeship Non-Levy Contract (procured) |
+    And the following earnings had been generated for the learner
+        | Delivery Period           | On-Programme | Completion | Balancing |
+        | Aug/Current Academic Year | 750          | 0          | 0         |
+        | Sep/Current Academic Year | 750          | 0          | 0         |
+        | Oct/Current Academic Year | 750          | 0          | 0         |
+        | Nov/Current Academic Year | 750          | 0          | 0         |
+        | Dec/Current Academic Year | 750          | 0          | 0         |
+        | Jan/Current Academic Year | 750          | 0          | 0         |
+        | Feb/Current Academic Year | 750          | 0          | 0         |
+        | Mar/Current Academic Year | 750          | 0          | 0         |
+        | Apr/Current Academic Year | 750          | 0          | 0         |
+        | May/Current Academic Year | 750          | 0          | 0         |
+        | Jun/Current Academic Year | 750          | 0          | 0         |
+        | Jul/Current Academic Year | 750          | 0          | 0         |
+		
+    And the following provider payments had been generated
+        | Collection Period         | Delivery Period           | SFA Co-Funded Payments | Employer Co-Funded Payments | Transaction Type |
+        | R01/Current Academic Year | Aug/Current Academic Year | 675                    | 75                          | Learning         |
+        
+    But the Provider now changes the Learner details as follows
+        | Priority | Start Date             | Planned Duration | Total Training Price | Total Training Price Effective Date | Total Assessment Price | Total Assessment Price Effective Date | Actual Duration | Completion Status | SFA Contribution Percentage | Contract Type | Aim Sequence Number | Aim Reference | Framework Code | Pathway Code | Programme Type | Funding Line Type                               |
+        | 1        | start of academic year | 12 months        | 11250                | Aug/Current Academic Year           | 0                      | Aug/Current Academic Year             | 42 days         | withdrawn         | 90%                         | Act2          | 1                   | ZPROG001      | 593            | 1            | 20             | 19+ Apprenticeship Non-Levy Contract (procured) |
+		 
+	And price details as follows
+		| Price Episode Id | Total Training Price | Total Training Price Effective Date | Total Assessment Price | Total Assessment Price Effective Date | Residual Training Price | Residual Training Price Effective Date | Residual Assessment Price | Residual Assessment Price Effective Date | SFA Contribution Percentage | Contract Type | Aim Sequence Number |
+		| pe-1             | 11250                | Aug/Current Academic Year           | 0                      | Aug/Current Academic Year             | 0                       |                                        | 0                         |                                          | 90%                         | Act2          | 1                   |
+	When the amended ILR file is re-submitted for the learners in collection period R06/Current Academic Year
+
+    Then the following learner earnings should be generated
+        | Delivery Period           | On-Programme | Completion | Balancing | Price Episode Identifier |
+        | Aug/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Sep/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Oct/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Nov/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Dec/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Jan/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Feb/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Mar/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Apr/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | May/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Jun/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+        | Jul/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    And only the following payments will be calculated
+        | Collection Period         | Delivery Period           | On-Programme | Completion | Balancing |
+        | R02/Current Academic Year | Aug/Current Academic Year | -750         | 0          | 0         |
+    And only the following provider payments will be recorded
+        | Collection Period         | Delivery Period           | SFA Co-Funded Payments | Employer Co-Funded Payments | Transaction Type |
+        | R02/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |
+    And at month end only the following provider payments will be generated
+        | Collection Period         | Delivery Period           | SFA Co-Funded Payments | Employer Co-Funded Payments | Transaction Type |
+        | R02/Current Academic Year | Aug/Current Academic Year | -675                   | -75                         | Learning         |

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Refunds/Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Refunds/Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
@@ -63,12 +63,12 @@ Then the following learner earnings should be generated
 
 And at month end only the following payments will be calculated
     | Collection Period         | Delivery Period           | On-Programme | Completion | Balancing |
-    | R02/Current Academic Year | Nov/Current Academic Year | -750         | 0          | 0         |
+    | R06/Current Academic Year | Aug/Current Academic Year | -750         | 0          | 0         |
 
 And only the following provider payments will be recorded
     | Collection Period         | Delivery Period           | Levy Payments | Transaction Type |
-    | R02/Current Academic Year | Nov/Current Academic Year | -750          | Learning         |
+    | R06/Current Academic Year | Aug/Current Academic Year | -750          | Learning         |
 
 And only the following provider payments will be generated
     | Collection Period         | Delivery Period           | Levy Payments | Transaction Type |
-    | R02/Current Academic Year | Nov/Current Academic Year | -750          | Learning         |
+    | R06/Current Academic Year | Aug/Current Academic Year | -750          | Learning         |

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Refunds/Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Refunds/Levy-learner withdrawn in 42 days, clawbacks are generated for previous payments - PV2-3642.feature
@@ -1,0 +1,74 @@
+﻿@basic_refund
+Feature: Levy Learner is withdrawn retrospectively PV2-3642
+	As a provider,
+	I want a levy learner, where levy is available the provider retrospectively notifies a withdrawal before 42 days and previously paid monthly instalments are refunded
+	So that I am accurately paid my apprenticeship provision.
+
+Scenario:  Provider retrospectively notifies of a withdrawal before 42 days for a levy learner after payments have already been made PV2-3642
+
+Given the employer levy account balance in collection period R02/Current Academic Year is 15000
+
+And the following commitments exist
+
+	| start date                   | end date                     | agreed price |Standard Code | Programme Type |
+	| 01/Aug/Current Academic Year | 31/Jul/Current Academic Year | 11250        |17            | 25             |
+
+And the provider previously submitted the following learner details
+    | Start Date                   | Planned Duration | Total Training Price | Total Training Price Effective Date | Total Assesment Price | Total Assesment Price Effective Date | Actual Duration | Completion Status | SFA Contribution Percentage | Contract Type | Aim Sequence Number | Aim Reference | Standard Code | Programme Type | Funding Line Type                                  |
+    | 04/Aug/Current Academic Year | 12 months        | 9000                 | 01/Aug/Current Academic Year        | 2250                  | 01/Aug/Current Academic Year         |                 | continuing        | 90%                         | Act1          | 1                   | ZPROG001      | 17            | 25             | 16-18 Apprenticeship (From May 2017) Levy Contract |
+
+And the following earnings had been generated for the learner
+    | Delivery Period           | On-Programme | Completion | Balancing |
+    | Aug/Current Academic Year | 750          | 0          | 0         |
+    | Sep/Current Academic Year | 750          | 0          | 0         |
+    | Oct/Current Academic Year | 750          | 0          | 0         |
+    | Nov/Current Academic Year | 750          | 0          | 0         |
+    | Dec/Current Academic Year | 750          | 0          | 0         |
+    | Jan/Current Academic Year | 750          | 0          | 0         |
+    | Feb/Current Academic Year | 750          | 0          | 0         |
+    | Mar/Current Academic Year | 750          | 0          | 0         |
+    | Apr/Current Academic Year | 750          | 0          | 0         |
+    | May/Current Academic Year | 750          | 0          | 0         |
+    | Jun/Current Academic Year | 750          | 0          | 0         |
+    | Jul/Current Academic Year | 750          | 0          | 0         |
+
+And the following provider payments had been generated
+    | Collection Period         | Delivery Period           | Levy Payments | Transaction Type |
+    | R01/Current Academic Year | Aug/Current Academic Year | 750           | Learning         |
+        
+But the Provider now changes the Learner details as follows
+    | Start Date                   | Planned Duration | Total Training Price | Total Assessment Price | Total Training Price Effective Date | Total Assesment Price Effective Date | Actual Duration | Completion Status | SFA Contribution Percentage | Contract Type | Aim Sequence Number | Aim Reference | Standard Code | Programme Type | Funding Line Type                                  |
+    | 04/Aug/Current Academic Year | 12 months        | 9000                 | 2250                   | 01/Aug/Current Academic Year        | 01/Aug/Current Academic Year         | 42 days         | withdrawn         | 90%                         | Act1          | 1                   | ZPROG001      | 17            | 25             | 16-18 Apprenticeship (From May 2017) Levy Contract |
+
+And price details as follows
+    | Price Episode Id | Total Training Price | Total Training Price Effective Date | Total Assessment Price | Total Assessment Price Effective Date | Residual Training Price | Residual Training Price Effective Date | Residual Assessment Price | Residual Assessment Price Effective Date | Contract Type | Aim Sequence Number | SFA Contribution Percentage |
+    | pe-1             | 9000                 | 01/Aug/Current Academic Year        | 2250                   | 01/Aug/Current Academic Year          | 0                       |                                        | 0                         |                                          | Act1          | 1                   | 90%                         |
+		 
+When the amended ILR file is re-submitted for the learners in collection period R06/Current Academic Year
+
+Then the following learner earnings should be generated
+    | Delivery Period           | On-Programme | Completion | Balancing | Price Episode Identifier |
+    | Aug/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Sep/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Oct/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Nov/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Dec/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Jan/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Feb/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Mar/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Apr/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | May/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Jun/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+    | Jul/Current Academic Year | 0            | 0          | 0         | pe-1                     |
+
+And at month end only the following payments will be calculated
+    | Collection Period         | Delivery Period           | On-Programme | Completion | Balancing |
+    | R02/Current Academic Year | Nov/Current Academic Year | -750         | 0          | 0         |
+
+And only the following provider payments will be recorded
+    | Collection Period         | Delivery Period           | Levy Payments | Transaction Type |
+    | R02/Current Academic Year | Nov/Current Academic Year | -750          | Learning         |
+
+And only the following provider payments will be generated
+    | Collection Period         | Delivery Period           | Levy Payments | Transaction Type |
+    | R02/Current Academic Year | Nov/Current Academic Year | -750          | Learning         |


### PR DESCRIPTION
PV2-3642 - Add Acceptance Tests for the scenario where learners are removed within 42 days. Clawbacks should be generated for this case. 

Changelog: 
- Added SpecFlow doc for Non-Levy learners removed within 42 days
- Added SpecFlow doc for Levy learners removed within 42 days
- Update the Training class used to convert the table data to ILR
- Update ToTimeSpan extension to accommodate for "X days" value for Actual Duration

New ATs Passed with the updated code from Earning Events and Required Payments. Build details - https://dev.azure.com/sfa-gov-uk/DCT/_releaseProgress?releaseId=255395&_a=release-pipeline-progress