### PR TITLE
Pv2 3783 update at remove apprenticeship updated handler

### DIFF
--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Steps/ProvidersRequiringResubmissionSteps.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Steps/ProvidersRequiringResubmissionSteps.cs
@@ -55,15 +55,6 @@ namespace SFA.DAS.Payments.AcceptanceTests.EndToEnd.Steps
             }, options);
         }
 
-        [Then(@"new record will be added to the ProviderRequiringReprocessing table")]
-        public async Task ThenNewRecordWillBeAddedToTheProviderRequiringReprocessingTable()
-        {
-            await WaitForIt(() =>
-            {
-                return dataContext.ProvidersRequiringReprocessing.AnyAsync(x => x.Ukprn == TestSession.Ukprn);
-            }, $"Failed to find provider with matching ukprn: {TestSession.Ukprn} in ProviderRequiringReprocessing table ");
-        }
-
         [Then(@"there should not be any change to ProviderRequiringReprocessing table")]
         public async Task ThenThereShouldNotBeAnyChangeToProviderRequiringReprocessingTable()
         {
@@ -94,6 +85,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.EndToEnd.Steps
             }, options);
         }
 
+        [Then("no record is added to the ProviderRequiringReprocessing table for that provider")]
         [Then(@"record for provider should be deleted from the ProviderRequiringReprocessing table")]
         public async Task ThenRecordForProviderShouldBeDeletedFromTheProviderRequiringReprocessingTable()
         {

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Steps/ProvidersRequiringResubmissionSteps.cs
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Steps/ProvidersRequiringResubmissionSteps.cs
@@ -55,6 +55,18 @@ namespace SFA.DAS.Payments.AcceptanceTests.EndToEnd.Steps
             }, options);
         }
 
+
+        [Then(@"no record is added to the ProviderRequiringReprocessing table for that provider")]
+        public async Task ThenNoRecordIsAddedToTheProviderRequiringReprocessingTableForThatProvider()
+        {
+            await WaitForIt(async () =>
+                {
+                    return !(await dataContext.ProvidersRequiringReprocessing.AnyAsync(x => x.Ukprn == TestSession.Ukprn));
+                }, $"Failed - Unexpected provider with ukprn: {TestSession.Ukprn} found in ProviderRequiringReprocessing table ");
+
+        }
+
+
         [Then(@"there should not be any change to ProviderRequiringReprocessing table")]
         public async Task ThenThereShouldNotBeAnyChangeToProviderRequiringReprocessingTable()
         {
@@ -85,14 +97,13 @@ namespace SFA.DAS.Payments.AcceptanceTests.EndToEnd.Steps
             }, options);
         }
 
-        [Then("no record is added to the ProviderRequiringReprocessing table for that provider")]
         [Then(@"record for provider should be deleted from the ProviderRequiringReprocessing table")]
         public async Task ThenRecordForProviderShouldBeDeletedFromTheProviderRequiringReprocessingTable()
         {
             await WaitForIt(async () =>
             {
                 return !(await dataContext.ProvidersRequiringReprocessing.AnyAsync(x => x.Ukprn == TestSession.Ukprn));
-            }, $"Failed to find provider with matching ukprn: {TestSession.Ukprn} in ProviderRequiringReprocessing table ");
+            }, $"Failed - Unexpected provider with ukprn: {TestSession.Ukprn} found in ProviderRequiringReprocessing table ");
 
         }
 

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Providers Requiring Resubmission/Providers Requiring Resubmission.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Providers Requiring Resubmission/Providers Requiring Resubmission.feature
@@ -6,12 +6,12 @@
 Scenario: Apprenticeship updated before ILR submitted by provider during current collection period
 	Given the provider has made no submissions in the current collection period 
 	When there is a change to the apprenticeship details for one of the provider's learners
-	Then new record will be added to the ProviderRequiringReprocessing table
+	Then no record is added to the ProviderRequiringReprocessing table for that provider
 
-Scenario: Apprenticeship updated after IRL submitted by provider during current collection period
+Scenario: Apprenticeship updated after ILR submitted by provider during current collection period
 	Given the provider has made a submission in the current collection period
 	When there is a change to the apprenticeship details for one of the provider's learners
-	Then new record will be added to the ProviderRequiringReprocessing table
+	Then no record is added to the ProviderRequiringReprocessing table for that provider
 
 Scenario: Apprenticeship updated before ILR submission but provider already exists in ProviderRequiringReprocessing table
 	Given a provider already exists in ProviderRequiringReprocessing table

--- a/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Providers Requiring Resubmission/Providers Requiring Resubmission.feature
+++ b/src/SFA.DAS.Payments.AcceptanceTests.EndToEnd/Tests/Providers Requiring Resubmission/Providers Requiring Resubmission.feature
@@ -8,7 +8,7 @@ Scenario: Apprenticeship updated before ILR submitted by provider during current
 	When there is a change to the apprenticeship details for one of the provider's learners
 	Then new record will be added to the ProviderRequiringReprocessing table
 
-Scenario: Apprenticeship updated after IRL submitted by provider during current collection period
+Scenario: Apprenticeship updated after ILR submitted by provider during current collection period
 	Given the provider has made a submission in the current collection period
 	When there is a change to the apprenticeship details for one of the provider's learners
 	Then new record will be added to the ProviderRequiringReprocessing table


### PR DESCRIPTION
Adjusted existing acceptance tests to reflect records not being added to the reprocessing table upon update - as a part of the changes made by removing references to the ApprenticeshipUpdatedHandler in PeriodEnd (PV2-3782)